### PR TITLE
Update tabulate version

### DIFF
--- a/Formula/pros-cli.rb
+++ b/Formula/pros-cli.rb
@@ -97,8 +97,8 @@ class ProsCli < Formula
   end
 
   resource "tabulate" do
-    url "https://files.pythonhosted.org/packages/57/6f/213d075ad03c84991d44e63b6516dd7d185091df5e1d02a660874f8f7e1e/tabulate-0.8.7.tar.gz"
-    sha256 "db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
+    url "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
+    sha256 "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"
   end
 
   resource "typing" do


### PR DESCRIPTION
Tabulate 8.7.0 has comparison issues with the python collections dependency solved in this PR: https://github.com/astanin/python-tabulate/pull/161. Updating tabulate version to resolve issues with python versions 3.10 and newer.