### PR TITLE
Update python version to officially supported version

### DIFF
--- a/Formula/pros-cli.rb
+++ b/Formula/pros-cli.rb
@@ -9,7 +9,7 @@ class ProsCli < Formula
   # for testing unreviewed changes
   head "https://github.com/purduesigbots/pros-cli.git", :branch => "develop"
 
-  depends_on "python@3.9"
+  depends_on "python@3.10.11"
 
   resource "cachetools" do
     url "https://files.pythonhosted.org/packages/49/c9/5791269161be47eacca42ffa0a87e0a4a1007b6dfbec0400ae36d43c08f7/cachetools-4.2.0.tar.gz"


### PR DESCRIPTION
The officially supported python version for the CLI is 3.10.11 as lower versions will not build properly with our dependencies and newer versions might contain breaking changes. We should define our "official" python version as the one that we package the CLI with which is specified [here](https://github.com/purduesigbots/pros-cli/blob/develop/.github/workflows/main.yml#L44).